### PR TITLE
metatag met slot in head

### DIFF
--- a/src/layouts/Main.astro
+++ b/src/layouts/Main.astro
@@ -29,6 +29,7 @@ import "@fontsource/zilla-slab/500.css";
         padding: 1em;
       }
     </style>
+    <slot name="head-extra" />
   </head>
   <body>
     <div class="container">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,6 +18,7 @@ const postsToShow = posts.slice(0, NumberDisplayPosts);
 ---
 
 <Main>
+  <meta content="noindex, follow" name="robots" slot="head-extra" />
   <section>
     <!-- <ul>
           {


### PR DESCRIPTION
Ik heb dus een extra named slot gemaakt in de "Main" layout. De voorpagina zet daar die meta tag in. De rest van de pagina's doen er niets mee.